### PR TITLE
Relative paths should always begin with `.` / `..`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ web:
   ports:
     - "80:80"
   volumes:
-    - app:/app
+    - ./app:/app
   links:
     - mysql
 mysql:


### PR DESCRIPTION
Relative paths should always begin with `.` or `..`

Reference:
https://docs.docker.com/compose/compose-file/#volumes-volume-driver
