### PR TITLE
Increase PHP memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ RUN apt-get update && \
 	apt-get install -yq git php5-dev libpcre3-dev && \
 	rm -rf /var/lib/apt/lists/*
 RUN	a2enmod rewrite
+RUN	sed -e 's/memory_limit\ =\ 128M/memory_limit = 512M/' -i /etc/php5/apache2/php.ini


### PR DESCRIPTION
When I generate 100.000 rows of data (maximum allowed by generatedata), I got memory related errors. So I increase the `memory_limit` in `php.ini`
